### PR TITLE
requirements: drop useless ecdsa/neo-mamba requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,3 @@ urllib3 >= 1.25.3, < 2.1.0
 pydantic >= 2
 typing-extensions >= 4.7.1
 python-magic == 0.4.27
-neo-mamba == 2.3.0
-ecdsa == 0.18.0


### PR DESCRIPTION
They're no longer needed, this should've been a part of 79b8e43957480c03b712e2ff1d574fd6ca6039cf or #12.